### PR TITLE
setSession to nil when recreating to avoid unnecessary call to CloseSession

### DIFF
--- a/client.go
+++ b/client.go
@@ -447,6 +447,10 @@ func (c *Client) monitor(ctx context.Context) {
 						c.setState(Reconnecting)
 						// create a new session to replace the previous one
 
+						// clear any previous session as we know the server has closed it
+						// this also prevents any unnecessary calls to CloseSession
+						c.setSession(nil)
+
 						dlog.Printf("trying to recreate session")
 						s, err := c.CreateSession(ctx, c.cfg.session)
 						if err != nil {


### PR DESCRIPTION
In the client.go monitor loop, the recreateSession action builds a new session on the assumption that the server is no longer holding the previous. It does not clear the value of atomicSession, which leads to CloseSession being called in ActivateSession even if there are no old sessions to be removed.